### PR TITLE
Add Icon-Caching and Notification Sound

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# This file is part of gotify-indicator
+#
+# Copyright (c) 2021 Felix Nüsse 
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from configurator import Configuration
+from config import CACHE_DIR
+import requests
+import threading
+import shutil
+
+
+class Cache(threading.Thread):
+
+    def __init__(self, https_protocol, base_url, client_token):
+        threading.Thread.__init__(self)
+        protocol = 'https' if https_protocol else 'http'
+        self.url = '{}://{}'.format(protocol, base_url)
+        self.client_token = client_token
+
+    def startCaching(self):
+        headers = {'X-Gotify-Key': self.client_token}
+        url = '{}/{}'.format(self.url, 'application')
+        ans = requests.get(url, headers=headers)
+        for app in ans.json():
+            imageurl = '{}/{}'.format(self.url, app['image'])
+            self.storeImage(imageurl, app['id'])
+        return ans.json()
+
+    def storeImage(self, imageurl, id):
+        image = requests.get(imageurl, stream=True)
+
+        image.raw.decode_content = True
+        with open(CACHE_DIR + str(id), 'wb') as target:
+            shutil.copyfileobj(image.raw, target)
+            print("written to: " + CACHE_DIR + str(id))
+
+    def instanciate(self):
+        configuration = Configuration()
+        preferences = configuration.get('preferences')
+
+        https_protocol = preferences['https_protocol']
+        base_url = preferences['base_url']
+        client_token = preferences['client_token']
+        cachepath = preferences['client_token']
+
+        cache = Cache(https_protocol,
+                      base_url,
+                      client_token)
+
+        cache.startCaching()

--- a/src/cache.py
+++ b/src/cache.py
@@ -3,7 +3,7 @@
 #
 # This file is part of gotify-indicator
 #
-# Copyright (c) 2021 Felix Nüsse 
+# Copyright (c) 2021 Felix Nüsse
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/src/cache.py
+++ b/src/cache.py
@@ -22,6 +22,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import os
 
 from configurator import Configuration
 from config import CACHE_DIR
@@ -51,18 +52,21 @@ class Cache(threading.Thread):
         image = requests.get(imageurl, stream=True)
 
         image.raw.decode_content = True
+        if not os.path.exists(CACHE_DIR):
+            os.mkdir(CACHE_DIR)
+
         with open(CACHE_DIR + str(id), 'wb') as target:
             shutil.copyfileobj(image.raw, target)
             print("written to: " + CACHE_DIR + str(id))
 
-    def instanciate(self):
+    @staticmethod
+    def instanciate():
         configuration = Configuration()
         preferences = configuration.get('preferences')
 
         https_protocol = preferences['https_protocol']
         base_url = preferences['base_url']
         client_token = preferences['client_token']
-        cachepath = preferences['client_token']
 
         cache = Cache(https_protocol,
                       base_url,

--- a/src/cache.py
+++ b/src/cache.py
@@ -4,7 +4,7 @@
 # This file is part of gotify-indicator
 #
 # Copyright (c) 2021 Felix Nüsse 
-
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights

--- a/src/config.py
+++ b/src/config.py
@@ -40,6 +40,7 @@ PARAMS = {'stats': {},
 
 CONFIG_DIR = os.path.join(os.path.expanduser('~'), '.config/gotify-indicator')
 CONFIG_FILE = os.path.join(CONFIG_DIR, 'gotify-indicator.conf')
+CACHE_DIR = os.path.join(os.path.expanduser('~'), '.cache/gotify-indicator/')
 
 
 def is_package():

--- a/src/config.py
+++ b/src/config.py
@@ -35,6 +35,7 @@ PARAMS = {'stats': {},
                           'application_name': '',
                           'application_token': '',
                           'client_token': '',
+                          'notification_sound': '',
                           'appid': ''}
           }
 
@@ -57,6 +58,7 @@ if is_package():
     APPDIR = os.path.join(ROOTDIR, APP)
     CHANGELOG = os.path.join(APPDIR, 'changelog')
     ICONDIR = os.path.join(ROOTDIR, 'icons')
+    SOUNDDIR = os.path.join(ROOTDIR, 'sounds')
     HTML_GRAPH = os.path.join(APPDIR, 'graph', 'graph.html')
     AUTOSTARTDIR = os.path.join(ROOTDIR, 'autostart')
 else:
@@ -66,6 +68,7 @@ else:
     DEBIANDIR = os.path.normpath(os.path.join(ROOTDIR, '../debian'))
     CHANGELOG = os.path.join(DEBIANDIR, 'changelog')
     ICONDIR = os.path.normpath(os.path.join(ROOTDIR, '../data/icons/'))
+    SOUNDDIR = os.path.normpath(os.path.join(ROOTDIR, '../data/sounds/'))
     HTML_GRAPH = os.path.join(ROOTDIR, 'graph', 'graph.html')
     AUTOSTARTDIR = os.path.normpath(
         os.path.join(ROOTDIR, '../data/autostart/'))

--- a/src/configurator.py
+++ b/src/configurator.py
@@ -27,6 +27,7 @@ import codecs
 import os
 import json
 from config import CONFIG_DIR
+from config import CACHE_DIR
 from config import CONFIG_FILE
 from config import PARAMS
 
@@ -43,6 +44,9 @@ class Configuration(object):
                 os.makedirs(CONFIG_DIR, 0o700)
             open(CONFIG_FILE, 'a').close()
             os.chmod(CONFIG_FILE, 0o600)
+
+        if not os.path.exists(CACHE_DIR):
+            os.makedirs(CACHE_DIR, 0o700)
 
     def has(self, key):
         return key in self.params.keys()

--- a/src/indicator.py
+++ b/src/indicator.py
@@ -280,6 +280,16 @@ SOFTWARE.''')
                                      message['message'],
                                      icon)
             self.notification.show()
+            play(self.getNotificationSound())
+
+    def getNotificationSound(self):
+        path = os.path.join(config.SOUNDDIR, 'default.mp3')
+        configuration = Configuration()
+        preferences = configuration.get('preferences')
+        custom_path = preferences['notification_sound']
+        if custom_path:
+            path = custom_path
+        return AudioSegment.from_mp3(path)
 
     def start(self):
         configuration = Configuration()

--- a/src/indicator.py
+++ b/src/indicator.py
@@ -50,6 +50,9 @@ import config
 from configurator import Configuration
 from client import GotifyClient
 from message_dialog import MessageDialog
+from cache import Cache
+from pydub import AudioSegment
+from pydub.playback import play
 
 
 class Indicator(object):
@@ -271,7 +274,7 @@ SOFTWARE.''')
 
     def on_message(self, message):
         message = json.loads(message)
-        icon = os.path.join(config.ICONDIR, 'gotify-indicator.svg')
+        icon=os.path.join(config.CACHE_DIR, str(message['appid']))
         if message['title'] != self.application_name:
             self.notification.update(message['title'],
                                      message['message'],
@@ -322,10 +325,15 @@ def main():
             dbus.bus.REQUEST_NAME_REPLY_PRIMARY_OWNER:
         print("application already running")
         exit(0)
-    Notify.init('gotify-indicator')
+
+    try:
+        Cache.instanciate()
+    except Exception:
+        print('Could not cache images!')
+
+    Notify.init('Gotify')
     Indicator()
     Gtk.main()
-
 
 if __name__ == '__main__':
     main()

--- a/src/indicator.py
+++ b/src/indicator.py
@@ -338,8 +338,8 @@ def main():
 
     try:
         Cache.instanciate()
-    except Exception:
-        print('Could not cache images!')
+    except Exception as e:
+        print('Could not cache images!'+str(e))
 
     Notify.init('Gotify')
     Indicator()

--- a/src/indicator.py
+++ b/src/indicator.py
@@ -274,7 +274,7 @@ SOFTWARE.''')
 
     def on_message(self, message):
         message = json.loads(message)
-        icon=os.path.join(config.CACHE_DIR, str(message['appid']))
+        icon = os.path.join(config.CACHE_DIR, str(message['appid']))
         if message['title'] != self.application_name:
             self.notification.update(message['title'],
                                      message['message'],

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -92,6 +92,16 @@ class Preferences(BaseDialog):
         self.autostart.set_halign(Gtk.Align.START)
         self.grid.attach(self.autostart, 1, 9, 1, 1)
 
+        self.grid.attach(Gtk.Separator(), 0, 11, 2, 1)
+        self.grid.attach(LeftLabel(_('Notification Sound:')), 0, 12, 1, 1)
+        self.notification_sound = Gtk.Entry.new()
+        self.notification_sound.set_editable(False)
+        self.notification_sound.connect('button_press_event', self.pickSound)
+        self.grid.attach(self.notification_sound, 1, 12, 1, 1)
+        self.notification_reset = Gtk.Button.new_with_label("Reset")
+        self.notification_reset.connect("clicked", self.resetSound)
+        self.grid.attach(self.notification_reset, 1, 13, 1, 1)
+
     def load(self):
         configuration = Configuration()
         preferences = configuration.get('preferences')
@@ -101,6 +111,11 @@ class Preferences(BaseDialog):
         self.application_name.set_text(preferences['application_name'])
         self.application_token.set_text(preferences['application_token'])
         self.client_token.set_text(preferences['client_token'])
+        self.notification_sound.set_text("")
+        try:
+            self.notification_sound.set_text(preferences['notification_sound'])
+        except:
+            print("No custom notification set!")
 
         self.theme_light.set_active(preferences['theme-light'])
 
@@ -120,6 +135,7 @@ class Preferences(BaseDialog):
         preferences['application_name'] = self.application_name.get_text()
         preferences['application_token'] = self.application_token.get_text()
         preferences['client_token'] = self.client_token.get_text()
+        preferences['notification_sound'] = self.notification_sound.get_text()
 
         preferences['theme-light'] = self.theme_light.get_active()
 
@@ -136,6 +152,30 @@ class Preferences(BaseDialog):
         else:
             if os.path.exists(autostart_file):
                 os.remove(autostart_file)
+
+    def resetSound(self, widget):
+        self.notification_sound.set_text("")
+
+    def pickSound(self, widget, event):
+        # https://python-gtk-3-tutorial.readthedocs.io/en/latest/dialogs.html#filechooserdialog
+        dialog = Gtk.FileChooserDialog(
+            title="Please choose a Notification Sound", parent=self, action=Gtk.FileChooserAction.OPEN
+        )
+        dialog.add_buttons(
+            Gtk.STOCK_CANCEL,
+            Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_OPEN,
+            Gtk.ResponseType.OK,
+        )
+
+        filter_text = Gtk.FileFilter()
+        filter_text.set_name("mp3 files")
+        filter_text.add_mime_type("audio/mpeg")
+        dialog.add_filter(filter_text)
+
+        if dialog.run() == Gtk.ResponseType.OK:
+            self.notification_sound.set_text(dialog.get_filename())
+        dialog.destroy()
 
 
 if __name__ == '__main__':

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -24,6 +24,7 @@
 # SOFTWARE.
 
 import gi
+
 try:
     gi.require_version('Gtk', '3.0')
     gi.require_version('Gdk', '3.0')
@@ -45,6 +46,7 @@ class LeftLabel(Gtk.Label):
         Gtk.Label.__init__(self)
         self.set_label(label)
         self.set_xalign(0)
+
 
 # class ClassicSwitch(Gt)
 
@@ -114,7 +116,7 @@ class Preferences(BaseDialog):
         self.notification_sound.set_text("")
         try:
             self.notification_sound.set_text(preferences['notification_sound'])
-        except:
+        except IndexError:
             print("No custom notification set!")
 
         self.theme_light.set_active(preferences['theme-light'])


### PR DESCRIPTION
This PR adds a cache for the application-images, so that the notifications are even more recognizable.
It also adds a notification sound that plays when a notification pops up. It tries to run a 'default.mp3' file which i did not add, since i dont have a file that i have the rights to add. However, this also provides a convenient ui to pick your own mp3.

It requires pyDub to be installed